### PR TITLE
Enable EVT to infer events type

### DIFF
--- a/src/Prismarine.ts
+++ b/src/Prismarine.ts
@@ -16,6 +16,7 @@ import RaknetConnectEvent from './events/raknet/RaknetConnectEvent';
 import PlayerConnectEvent from './events/player/PlayerConnectEvent';
 import RaknetDisconnectEvent from './events/raknet/RaknetDisconnectEvent';
 import RaknetEncapsulatedPacketEvent from './events/raknet/RaknetEncapsulatedPacketEvent';
+import { to } from "evt";
 
 const Listener = require('@jsprismarine/raknet');
 const BatchPacket = require('./network/packet/batch');
@@ -96,26 +97,26 @@ export default class Prismarine {
         this.raknet.name.setMotd(this.config.getMotd());
         this.raknet.on('openConnection', async (connection: any) => {
             const event = new RaknetConnectEvent(connection);
-            await this.getEventManager().post(['raknetConnect', event]);
+            this.getEventManager().post(['raknetConnect', event]);
         });
         this.raknet.on('closeConnection', async (inetAddr: any, reason: string) => {
             const event = new RaknetDisconnectEvent(
                 inetAddr,
                 reason
             );
-            await this.getEventManager().post(['raknetDisconnect', event]);
+            this.getEventManager().post(['raknetDisconnect', event]);
         });
         this.raknet.on('encapsulated', async (packet: any, inetAddr: any) => {
             const event = new RaknetEncapsulatedPacketEvent(
                 inetAddr,
                 packet
             );
-            await this.getEventManager().post(['raknetEncapsulatedPacket', event]);
+            this.getEventManager().post(['raknetEncapsulatedPacket', event]);
         });
 
         this.logger.info(`JSPrismarine is now listening on port §b${port}`);
 
-        this.getEventManager().on('raknetConnect', async (event: RaknetConnectEvent) => {
+        this.getEventManager().$attach(to('raknetConnect'), async event => {
             const connection = event.getConnection();
 
             return new Promise(async (resolve, reject) => {
@@ -137,7 +138,7 @@ export default class Prismarine {
 
                     // Emit playerConnect event
                     const event = new PlayerConnectEvent(player, inetAddr);
-                    await this.getEventManager().post(['playerConnect', event]);
+                    this.getEventManager().post(['playerConnect', event]);
                     if (event.cancelled)
                         return reject();
 
@@ -154,7 +155,7 @@ export default class Prismarine {
             })
         });
 
-        this.getEventManager().on('raknetDisconnect', async (event: RaknetDisconnectEvent) => {
+        this.getEventManager().$attach(to('raknetDisconnect'), async event => {
             const inetAddr = event.getInetAddr();
             const reason = event.getReason();
 
@@ -185,7 +186,7 @@ export default class Prismarine {
             });
         });
 
-        this.getEventManager().on('raknetEncapsulatedPacket', async (event: RaknetEncapsulatedPacketEvent) => {
+        this.getEventManager().$attach(to('raknetEncapsulatedPacket'), async event => {
             const packet = event.getPacket();
             const inetAddr = event.getInetAddr();
 

--- a/src/events/EventManager.ts
+++ b/src/events/EventManager.ts
@@ -1,4 +1,4 @@
-import { Evt, to } from 'evt';
+import { Evt } from 'evt';
 import type Prismarine from '../Prismarine';
 import type ChatEvent from './chat/ChatEvent';
 import type PlayerConnectEvent from './player/PlayerConnectEvent';
@@ -23,13 +23,5 @@ export default class EventManager extends Evt<
     > {
     constructor(server: Prismarine) {
         super();
-    }
-
-    public async on(id: string, callback: any) {
-        return await this.$attach(to(id as any), callback);
-    }
-
-    public async emit(id: string, callback: any) {
-        return await this.post([id, callback] as any);
     }
 };

--- a/src/plugin/api/versions/1.0/EventManager.ts
+++ b/src/plugin/api/versions/1.0/EventManager.ts
@@ -8,10 +8,12 @@ export default class EventManager {
         this.server = server;
     }
 
-    public async on(id: string, callback: any) {
-        return await this.server.getEventManager().on(id, callback);
-    }
-    public async emit(id: string, value: any) {
-        return await this.server.getEventManager().emit(id, value);
-    }
+    private get em(){ return this.server.getEventManager(); }
+
+    /*
+    get $attach(){ return this.em.$attach.bind(this.em); }
+
+    get post() { return this.em.post.bind(this.em); }
+    */
+
 };


### PR DESCRIPTION
Hello,

Nice work on this project! 🚀 

I am the author of EVT. I noticed you did not enable the lib to infer the types of the events for you or to provide you type safety. So I made a PR to show you how I would do it in this paradigm.

If you commit the the Evt api the lib can list for you all the available events and give you a type error if you did a typo: 
![image](https://user-images.githubusercontent.com/6702424/96942871-a3499f00-14d6-11eb-9172-af71c2ef8903.png)

You also get the type of the event inferred without having to introduce type annotations: 
![image](https://user-images.githubusercontent.com/6702424/96942890-afcdf780-14d6-11eb-8959-c02cfbd8f07a.png)

I also noticed that you where awaiting the result of `post` and `$attach`, this has no effect. Evt is synchronous as the `EventEmitter` is. Meaning, when you invoke post all the attached handler are invoked synchronously. Post only return a number that represent the number of handler that have been invoked. 
`await`ing a `number` has no effect. Cf: 

![image](https://user-images.githubusercontent.com/6702424/96943141-8cf01300-14d7-11eb-9b32-d9be1dc94df0.png)

Same thing for `$attach`, it only returns the Evt instance, there is nothing to `await`.

If you want to asynchronously wait for an event what you can do for example is:

```typescript
const em = new EventManager(...);

const playerMoveEvent = await em.waitFor(to("playerMove"));
```

There is also [`.postAsyncOnceHandled()`](https://docs.evt.land/api/evt/post#evt-postasynconcehandled-data) if you want to wait before posting that there is at least one handler attached. This return a promise that you can await...

I also did an other pull request to suggest an other approach, instead of having a single Evt instance for every Event type you can have a single instance for each. It's a matter of taste any way you can have a look at the other PR.

Cheers