### PR TITLE
Fix false warn

### DIFF
--- a/packages/prismarine/src/plugin/PluginManager.ts
+++ b/packages/prismarine/src/plugin/PluginManager.ts
@@ -136,7 +136,7 @@ export default class PluginManager {
             return null;
         }
 
-        if (dir.includes('.jspz'))
+        if (!dir.endsWith('.jspz'))
             this.server
                 .getLogger()
                 .warn(


### PR DESCRIPTION
Fixed a bug where it will warn that a plugin is not a .jspz but it is.
This also checks if the plugin is a .jspz