### PR TITLE
fix(project): fix load jsprismarine and vanilla commands error

### DIFF
--- a/packages/prismarine/src/command/CommandManager.ts
+++ b/packages/prismarine/src/command/CommandManager.ts
@@ -30,10 +30,10 @@ export default class CommandManager {
 
         const commands = [
             ...fs
-                .readdirSync(path.join(/file:\/{2,3}(.+)\/[^/]/.exec(import.meta.url)![1], 'vanilla'))
+                .readdirSync(path.join(/file:\/{1,2}(.+)\/[^/]/.exec(import.meta.url)![1], 'vanilla'))
                 .map((a) => `/vanilla/${a}`),
             ...fs
-                .readdirSync(path.join(/file:\/{2,3}(.+)\/[^/]/.exec(import.meta.url)![1], 'jsprismarine'))
+                .readdirSync(path.join(/file:\/{1,2}(.+)\/[^/]/.exec(import.meta.url)![1], 'jsprismarine'))
                 .map((a) => `/jsprismarine/${a}`)
         ];
 


### PR DESCRIPTION
When i execute "npm run dev" i had that error:
![image](https://user-images.githubusercontent.com/44149740/212485790-41c745d6-88f3-4b99-a258-c81108177917.png)

This PR fix the error

![image](https://user-images.githubusercontent.com/44149740/212485812-249eafc2-2772-46ec-895b-83ddf398db68.png)
