### PR TITLE
fix(project): Fix plugin loader

### DIFF
--- a/packages/prismarine/src/plugin/PluginManager.ts
+++ b/packages/prismarine/src/plugin/PluginManager.ts
@@ -107,7 +107,8 @@ export default class PluginManager {
                     `PluginManager/registerPlugin/${id}`
                 );
 
-        const pkg = await import(path.join(dir, 'package.json'));
+        const packagePluginFile = await fs.promises.readFile(path.join(dir, 'package.json'));
+        const pkg = JSON.parse(packagePluginFile.toString());
         if (!pkg) throw new Error(`package.json is missing!`);
 
         if (!pkg.name || !pkg.prismarine) throw new Error(`package.json is invalid!`);


### PR DESCRIPTION
After the project was moved to ESM, we have the error on plugin loader:
![image](https://user-images.githubusercontent.com/46273354/212492247-efb94c33-9a7a-4ce4-b47c-d76f5999f913.png)

With the update, the problem has fixed.
![image](https://user-images.githubusercontent.com/46273354/212492286-eae10f6b-3e0a-4f11-88ae-5dc512e52347.png)
