### PR TITLE
Prismarine+Errors: Add `@jsprismarine/errors` package for shared errors.

### DIFF
--- a/packages/errors/.npmignore
+++ b/packages/errors/.npmignore
@@ -1,0 +1,14 @@
+node_modules/
+packages/
+src/
+/worlds/
+/logs/
+docs/
+.test/
+.github/
+.turbo/
+jsp/
+packages/
+/*.json
+jest*
+!package.json

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @jsprismarine/color-parser
+
+## 0.1.1
+
+### Patch Changes
+
+- [`80e23e1`](https://github.com/JSPrismarine/JSPrismarine/commit/80e23e17c0111eac2df98f73cdeec5730bd9abf5) Thanks [@filiphsps](https://github.com/filiphsps)! - Include CHANGELOG.md with releases.
+
+## 0.1.0
+
+### Patch Changes
+
+- [#1226](https://github.com/JSPrismarine/JSPrismarine/pull/1226) [`20b3cb1`](https://github.com/JSPrismarine/JSPrismarine/commit/20b3cb1ee1e2a2c5c45275f9c2a23c9c2507dcf5) Thanks [@filiphsps](https://github.com/filiphsps)! - - Migrated to vite.
+  - The build system has been refactored to support both esm and cjs.
+  - Releases are now managed by changeset.

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -1,0 +1,1 @@
+# JSPrismarine/color-parser

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,0 +1,55 @@
+{
+    "name": "@jsprismarine/errors",
+    "version": "0.1.1",
+    "description": "JSPrismarine shared errors",
+    "sideEffects": false,
+    "type": "module",
+    "files": [
+        "dist",
+        "CHANGELOG.md",
+        "README.md"
+    ],
+    "module": "./dist/index.es.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/index.es.js",
+            "module": "./dist/index.es.js",
+            "require": "./dist/index.cjs.js",
+            "types": "./dist/index.d.ts"
+        },
+        "./*": {
+            "import": "./dist/*.es.js",
+            "module": "./dist/*.es.js",
+            "require": "./dist/*.cjs.js",
+            "types": "./dist/*.d.ts"
+        },
+        "./package.json": "./package.json"
+    },
+    "funding": "https://github.com/sponsors/JSPrismarine",
+    "scripts": {
+        "clean": "rimraf dist jsp tsconfig.tsbuildinfo",
+        "build": "vite build",
+        "typecheck": "tsc -noEmit"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/JSPrismarine/JSPrismarine.git"
+    },
+    "keywords": [
+        "nodejs",
+        "raknet"
+    ],
+    "author": "JSPrismarine",
+    "license": "MIT",
+    "homepage": "https://github.com/JSPrismarine/JSPrismarine/tree/master/packages/errors",
+    "devDependencies": {
+        "@types/node": "20.12.2",
+        "glob": "10.3.12",
+        "rimraf": "5.0.5",
+        "typescript": "5.4.3",
+        "vite": "5.2.7",
+        "vitest": "1.4.0"
+    },
+    "dependencies": {}
+}

--- a/packages/errors/src/error.ts
+++ b/packages/errors/src/error.ts
@@ -1,0 +1,1 @@
+export const BuiltinError = Error;

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,0 +1,53 @@
+import { BuiltinError } from './error';
+
+export enum ErrorKind {
+    GENERIC_NAMESPACE_INVALID = 'GENERIC_NAMESPACE_INVALID',
+
+    COMMAND_UNKNOWN_COMMAND = 'COMMAND_UNKNOWN_Command',
+    COMMAND_REGISTER_CLASS_MALFORMED_OR_MISSING = 'COMMAND_REGISTER_CLASS_MALFORMED_OR_MISSING'
+}
+
+export class Error<T = ErrorKind> extends BuiltinError {
+    public readonly name: string = 'Error';
+    public readonly message!: string;
+    public readonly code!: T;
+
+    public constructor() {
+        super(...arguments);
+        Object.setPrototypeOf(this, BuiltinError.prototype);
+        Object.setPrototypeOf(this, Error.prototype);
+    }
+}
+
+export class GenericNamespaceInvalidError extends Error {
+    name = 'NamespaceInvalidError';
+    message = `The namespace is malformed or invalid.`;
+    code = ErrorKind.GENERIC_NAMESPACE_INVALID;
+
+    public constructor() {
+        super();
+        Object.setPrototypeOf(this, GenericNamespaceInvalidError.prototype);
+    }
+}
+
+export class CommandUnknownCommandError extends Error {
+    name = 'UnknownCommandError';
+    message = `Unknown command.`;
+    code = ErrorKind.COMMAND_UNKNOWN_COMMAND;
+
+    public constructor() {
+        super();
+        Object.setPrototypeOf(this, CommandUnknownCommandError.prototype);
+    }
+}
+
+export class CommandRegisterClassMalformedOrMissingError extends Error {
+    name = 'CommandRegisterClassMalformedOrMissingError';
+    message = `Command class is malformed or missing.`;
+    code = ErrorKind.COMMAND_REGISTER_CLASS_MALFORMED_OR_MISSING;
+
+    public constructor() {
+        super();
+        Object.setPrototypeOf(this, CommandRegisterClassMalformedOrMissingError.prototype);
+    }
+}

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig.json",
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "composite": false,
+        "paths": { "@": ["src/index.ts"], "@/*": ["src/*"] },
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "typeRoots": ["./node_modules/@types", "./src/@types", "./dist/index.d.ts"]
+    },
+    "exclude": ["node_modules", "coverage", "dist", "src/**/*.test.*"],
+    "include": ["src", "./src/@types"]
+}

--- a/packages/errors/typedoc.json
+++ b/packages/errors/typedoc.json
@@ -1,0 +1,3 @@
+{
+    "entryPoints": ["src/index.ts"]
+}

--- a/packages/errors/vite.config.ts
+++ b/packages/errors/vite.config.ts
@@ -1,0 +1,44 @@
+import { globSync } from 'glob';
+import { dirname, extname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig, mergeConfig } from 'vite';
+import pkg from './package.json' assert { type: 'json' };
+
+import base from '../../vite.config';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const input = Object.fromEntries(
+    globSync('./**/src/**/*.ts*', {
+        ignore: ['**/*.d.ts', '**/coverage/**', '**/dist/**', '**/node_modules/**', '**/*.test.*']
+    }).map((file) => {
+        const filenameWithoutExt = file.slice(0, file.length - extname(file).length);
+
+        return [relative('src', filenameWithoutExt), resolve(process.cwd(), file)];
+    })
+);
+
+export default mergeConfig(
+    base,
+    defineConfig({
+        root: __dirname,
+        resolve: {
+            alias: {
+                '@/': resolve(__dirname, 'src/'),
+                '@': resolve(__dirname, 'src/index.ts')
+            }
+        },
+        build: {
+            lib: {
+                entry: input,
+                formats: ['es', 'cjs'],
+                fileName: (format, name) => `${name}.${format}.js`,
+                name: pkg.name
+            },
+            rollupOptions: {
+                external: [...Object.keys(pkg.dependencies)]
+            }
+        }
+    })
+);

--- a/packages/errors/vitest.config.ts
+++ b/packages/errors/vitest.config.ts
@@ -1,0 +1,26 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineProject, mergeConfig } from 'vitest/config';
+
+import base from '../../vitest.config';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default mergeConfig(
+    base,
+    defineProject({
+        root: resolve(__dirname),
+        resolve: {
+            alias: {
+                '@/': resolve(__dirname, 'src/'),
+                '@': resolve(__dirname, 'src/index.ts')
+            }
+        },
+        test: {
+            typecheck: {
+                tsconfig: `${__dirname}/tsconfig.test.json`
+            }
+        }
+    })
+);

--- a/packages/prismarine/package.json
+++ b/packages/prismarine/package.json
@@ -69,6 +69,7 @@
     },
     "dependencies": {
         "@jsprismarine/color-parser": "workspace:*",
+        "@jsprismarine/errors": "workspace:*",
         "@jsprismarine/jsbinaryutils": "5.5.3",
         "@jsprismarine/nbt": "workspace:*",
         "@jsprismarine/raknet": "workspace:*",

--- a/packages/prismarine/src/command/Command.ts
+++ b/packages/prismarine/src/command/Command.ts
@@ -1,4 +1,4 @@
-import type { CommandDispatcher } from '@jsprismarine/brigadier';
+import { ArgumentCommandNode, type CommandDispatcher } from '@jsprismarine/brigadier';
 import type Player from '../Player';
 
 interface CommandProps {
@@ -47,4 +47,16 @@ export default class Command {
      * @deprecated Replaced with "Command.register"
      */
     public async execute(_sender: Player, _args: any[]): Promise<any> {}
+
+    public usage(dispatcher: CommandDispatcher<any>): string {
+        // TODO: Improve this, it's not really accurate right now.
+        return Array.from(dispatcher.findNode([this.id.split(':').at(-1)!]).getChildren())
+            .map((child) => {
+                if (!(child instanceof ArgumentCommandNode)) return null;
+                return child.getUsageText();
+            })
+            .filter(Boolean)
+            .join(' ')
+            .trim();
+    }
 }

--- a/packages/prismarine/src/command/vanilla/HelpCommand.ts
+++ b/packages/prismarine/src/command/vanilla/HelpCommand.ts
@@ -1,7 +1,8 @@
-import { CommandDispatcher, literal } from '@jsprismarine/brigadier';
+import type { CommandDispatcher } from '@jsprismarine/brigadier';
+import { literal } from '@jsprismarine/brigadier';
 
 import Command from '../Command';
-import { Player } from '../../';
+import type { Player } from '../../';
 
 export default class HelpCommand extends Command {
     public constructor() {
@@ -24,8 +25,12 @@ export default class HelpCommand extends Command {
                 .forEach(async (command) => {
                     if (!source.getServer().getPermissionManager().can(source).execute(command.permission)) return;
 
-                    // TODO: handle multiple commands with the same id but different namespaces
-                    await source.sendMessage(`§e/${command.id.split(':')[1]}:§r §7${command.description}`);
+                    const usage = command.usage(dispatcher);
+
+                    // TODO: deal with commands sharing the same name but not namespace (`minecraft:help` + `some-plugin:help`).
+                    await source.sendMessage(
+                        `§e/${command.id.split(':').at(-1)}§r${(usage && ` §b${usage}§r`) || ''}: §7${command.description}`
+                    );
                 });
         };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,27 @@ importers:
         specifier: 1.4.0
         version: 1.4.0(@types/node@20.12.2)
 
+  packages/errors:
+    devDependencies:
+      '@types/node':
+        specifier: 20.12.2
+        version: 20.12.2
+      glob:
+        specifier: 10.3.12
+        version: 10.3.12
+      rimraf:
+        specifier: 5.0.5
+        version: 5.0.5
+      typescript:
+        specifier: 5.4.3
+        version: 5.4.3
+      vite:
+        specifier: 5.2.7
+        version: 5.2.7(@types/node@20.12.2)
+      vitest:
+        specifier: 1.4.0
+        version: 1.4.0(@types/node@20.12.2)
+
   packages/nbt:
     dependencies:
       '@jsprismarine/jsbinaryutils':
@@ -240,6 +261,9 @@ importers:
       '@jsprismarine/color-parser':
         specifier: workspace:*
         version: link:../color-parser
+      '@jsprismarine/errors':
+        specifier: workspace:*
+        version: link:../errors
       '@jsprismarine/jsbinaryutils':
         specifier: 5.5.3
         version: 5.5.3


### PR DESCRIPTION
This is an approach taken from https://github.com/NordcomInc.