### PR TITLE
Prismarine: Rename on{En,Dis}able to {en,dis}able.

### DIFF
--- a/.changeset/fearless.md
+++ b/.changeset/fearless.md
@@ -1,0 +1,5 @@
+---
+"@jsprismarine/prismarine": patch
+---
+
+Rename `onEnable` and `onDisable` to `enable` and `disable`.

--- a/packages/prismarine/src/Console.ts
+++ b/packages/prismarine/src/Console.ts
@@ -1,7 +1,7 @@
+import readline from 'node:readline';
 import { Chat } from './chat/Chat';
 import ChatEvent from './events/chat/ChatEvent';
 import Vector3 from './math/Vector3';
-import readline from 'node:readline';
 
 import { EntityLike } from './entity/Entity';
 import type Server from './Server';
@@ -101,7 +101,7 @@ export default class Console extends EntityLike {
         this.cli.on('close', async () => await this.server.shutdown());
     }
 
-    public async onEnable(): Promise<void> {
+    public async enable(): Promise<void> {
         this.server.on('chat', async (evt: ChatEvent) => {
             if (evt.isCancelled()) return;
             await this.sendMessage(evt.getChat().getMessage());
@@ -109,7 +109,7 @@ export default class Console extends EntityLike {
         this.server.getLogger().setConsole(this);
     }
 
-    public async onDisable(isReload: boolean = false): Promise<void> {
+    public async disable(isReload: boolean = false): Promise<void> {
         if (!isReload) return;
 
         this.cli.removeAllListeners();

--- a/packages/prismarine/src/Player.ts
+++ b/packages/prismarine/src/Player.ts
@@ -124,7 +124,7 @@ export default class Player extends Human {
         server.on('chat', this.chatHandler);
     }
 
-    public async onEnable() {
+    public async enable() {
         this.permissions = await this.getServer().getPermissionManager().getPermissions(this);
 
         const playerData = await this.getWorld().getPlayerData(this);
@@ -165,7 +165,7 @@ export default class Player extends Human {
         this.connected = true;
     }
 
-    public async onDisable() {
+    public async disable() {
         if (this.connected && this.xuid) await this.getWorld().savePlayerData(this);
         this.server.removeListener('chat', this.chatHandler);
 
@@ -262,7 +262,7 @@ export default class Player extends Human {
         this.currentChunk = null;
         await this.networkSession.clearChunks();
         await this.networkSession.needNewChunks();
-        await this.onEnable();
+        await this.enable();
         await this.networkSession.sendPlayStatus(PlayStatusType.PlayerSpawn);
     }
 

--- a/packages/prismarine/src/ban/BanManager.test.ts
+++ b/packages/prismarine/src/ban/BanManager.test.ts
@@ -3,9 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import BanManager from './BanManager';
 import type Server from '../Server';
 import { cwd } from '../utils/cwd';
+import BanManager from './BanManager';
 
 describe('ban', () => {
     describe('BanManager', () => {
@@ -30,14 +30,14 @@ describe('ban', () => {
         describe('onEnable', () => {
             it('should call parseBanned', async () => {
                 const parseBannedSpy = vi.spyOn(banManager, 'parseBanned' as const as keyof BanManager);
-                await banManager.onEnable();
+                await banManager.enable();
                 expect(parseBannedSpy).toHaveBeenCalled();
             });
         });
 
         describe('onDisable', () => {
             it('should clear the banned map', async () => {
-                banManager.onDisable();
+                banManager.disable();
                 expect(banManager['banned'].size).toBe(0);
             });
         });

--- a/packages/prismarine/src/ban/BanManager.ts
+++ b/packages/prismarine/src/ban/BanManager.ts
@@ -2,10 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import util from 'node:util';
 
+import minifyJson from 'strip-json-comments';
 import type Player from '../Player';
 import type Server from '../Server';
 import { cwd } from '../utils/cwd';
-import minifyJson from 'strip-json-comments';
 
 /**
  * Ban manager.
@@ -23,11 +23,11 @@ export default class BanManager {
         this.server = server;
     }
 
-    public async onEnable() {
+    public async enable() {
         await this.parseBanned();
     }
 
-    public async onDisable() {
+    public async disable() {
         this.banned.clear();
     }
 

--- a/packages/prismarine/src/block/BlockIdsType.test.ts
+++ b/packages/prismarine/src/block/BlockIdsType.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
+import LoggerBuilder from '../utils/Logger';
 import { BlockIdsType } from './BlockIdsType';
 import BlockManager from './BlockManager';
-import LoggerBuilder from '../utils/Logger';
 
 describe('block', () => {
     describe('BlockIdsType', () => {
@@ -11,7 +11,7 @@ describe('block', () => {
             const blockManager = new BlockManager({
                 getLogger: () => new LoggerBuilder()
             } as any);
-            await blockManager.onEnable();
+            await blockManager.enable();
 
             for (const blockId in BlockIdsType) {
                 if (Number.isNaN(Number(blockId))) {

--- a/packages/prismarine/src/block/BlockManager.ts
+++ b/packages/prismarine/src/block/BlockManager.ts
@@ -1,10 +1,10 @@
 import * as Blocks from './Blocks';
 
+import type Server from '../Server';
+import BlockRegisterEvent from '../events/block/BlockRegisterEvent';
+import Timer from '../utils/Timer';
 import type { Block } from './Block';
 import { BlockIdsType } from './BlockIdsType';
-import BlockRegisterEvent from '../events/block/BlockRegisterEvent';
-import type Server from '../Server';
-import Timer from '../utils/Timer';
 
 export default class BlockManager {
     private readonly server: Server;
@@ -18,14 +18,14 @@ export default class BlockManager {
     /**
      * OnEnable hook.
      */
-    public async onEnable() {
+    public async enable() {
         await this.importBlocks();
     }
 
     /**
      * OnDisable hook.
      */
-    public async onDisable() {
+    public async disable() {
         this.blocks.clear();
     }
 

--- a/packages/prismarine/src/command/CommandManager.test.ts
+++ b/packages/prismarine/src/command/CommandManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { CommandManager, Command, Commands } from './';
 import type { Server } from '../';
+import { Command, CommandManager, Commands } from './';
 
 describe('command', () => {
     describe('CommandManager', () => {
@@ -21,7 +21,7 @@ describe('command', () => {
 
             // Mock the registerClassCommand method
             commandManager.registerCommand = vi.fn();
-            await commandManager.onEnable();
+            await commandManager.enable();
 
             expect(commandManager.registerCommand).toHaveBeenCalledTimes(Object.keys(Commands).length);
         });
@@ -30,7 +30,7 @@ describe('command', () => {
             const commandManager = new CommandManager(server);
 
             (commandManager as any).commands.set('test', new Command({} as any));
-            await commandManager.onDisable();
+            await commandManager.disable();
 
             expect(commandManager.getCommands().size).toBe(0);
         });

--- a/packages/prismarine/src/command/CommandManager.ts
+++ b/packages/prismarine/src/command/CommandManager.ts
@@ -23,7 +23,7 @@ export class CommandManager implements Service {
         this.dispatcher = new CommandDispatcher();
     }
 
-    public async onEnable() {
+    public async enable() {
         const timer = new Timer();
 
         const commands = Object.keys(Commands).map((key) => (Commands as any)[key] as typeof Command);
@@ -51,7 +51,7 @@ export class CommandManager implements Service {
             .verbose(`Registered §b${this.commands.size}§r commands(s) (took §e${timer.stop()} ms§r)!`);
     }
 
-    public async onDisable() {
+    public async disable() {
         this.commands.clear();
         // TODO: clear commands in dispatcher
     }

--- a/packages/prismarine/src/config/Config.test.ts
+++ b/packages/prismarine/src/config/Config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Config } from './Config';
 
@@ -8,7 +8,7 @@ describe('config', () => {
 
         beforeEach(async () => {
             config = new Config();
-            await config.onEnable();
+            await config.enable();
         });
 
         it('should have the default server port', () => {

--- a/packages/prismarine/src/config/Config.ts
+++ b/packages/prismarine/src/config/Config.ts
@@ -1,7 +1,7 @@
-import { ConfigBuilder } from './ConfigBuilder';
-import { Gamemode } from '../world/';
 import { SeedGenerator } from '../utils/Seed';
 import { cwd } from '../utils/cwd';
+import { Gamemode } from '../world/';
+import { ConfigBuilder } from './ConfigBuilder';
 
 import path from 'node:path';
 
@@ -21,7 +21,7 @@ export class Config {
 
     public constructor() {}
 
-    public async onEnable(): Promise<void> {
+    public async enable(): Promise<void> {
         const isDev = process.env.NODE_ENV === 'development';
 
         this.configBuilder = new ConfigBuilder(path.resolve(cwd(), 'config.yaml'));
@@ -45,7 +45,7 @@ export class Config {
         this.packetCompressionLevel = this.configBuilder.get('packet-compression-level', 7) as number;
     }
 
-    public async onDisable(): Promise<void> {}
+    public async disable(): Promise<void> {}
 
     /**
      * Get the server's port.

--- a/packages/prismarine/src/item/ItemManager.ts
+++ b/packages/prismarine/src/item/ItemManager.ts
@@ -1,9 +1,9 @@
 import * as Items from './Items';
 
-import type { Item } from './Item';
-import ItemRegisterEvent from '../events/items/ItemRegisterEvent';
 import type Server from '../Server';
+import ItemRegisterEvent from '../events/items/ItemRegisterEvent';
 import Timer from '../utils/Timer';
+import type { Item } from './Item';
 
 // TODO: Don't dynamically import, do it like ./network/Protocol etc
 export default class ItemManager {
@@ -24,7 +24,7 @@ export default class ItemManager {
      * OnEnable hook.
      * @async
      */
-    public async onEnable() {
+    public async enable() {
         await this.importItems();
     }
 
@@ -32,7 +32,7 @@ export default class ItemManager {
      * OnDisable hook.
      * @async
      */
-    public async onDisable() {
+    public async disable() {
         this.items.clear();
     }
 

--- a/packages/prismarine/src/network/PacketRegistry.ts
+++ b/packages/prismarine/src/network/PacketRegistry.ts
@@ -1,12 +1,12 @@
 import * as Handlers from './Handlers';
 import * as Packets from './Packets';
 
-import Identifiers from './Identifiers';
-import type PacketHandler from './handler/PacketHandler';
 import type { PlayerSession } from '../';
-import type PreLoginPacketHandler from './handler/PreLoginPacketHandler';
 import type Server from '../Server';
 import Timer from '../utils/Timer';
+import Identifiers from './Identifiers';
+import type PacketHandler from './handler/PacketHandler';
+import type PreLoginPacketHandler from './handler/PreLoginPacketHandler';
 
 export default class PacketRegistry {
     private server: Server;
@@ -17,12 +17,12 @@ export default class PacketRegistry {
         this.server = server;
     }
 
-    public async onEnable() {
+    public async enable() {
         await this.registerPackets();
         await this.registerHandlers();
     }
 
-    public async onDisable() {
+    public async disable() {
         this.handlers.clear();
         this.packets.clear();
     }

--- a/packages/prismarine/src/network/handler/LoginHandler.ts
+++ b/packages/prismarine/src/network/handler/LoginHandler.ts
@@ -1,12 +1,12 @@
+import { Player } from '../../';
+import type Server from '../../Server';
 import type ClientConnection from '../ClientConnection';
 import Identifiers from '../Identifiers';
-import type LoginPacket from '../packet/LoginPacket';
 import { PlayStatusPacket } from '../Packets';
-import PlayStatusType from '../type/PlayStatusType';
-import { Player } from '../../';
-import type PreLoginPacketHandler from './PreLoginPacketHandler';
+import type LoginPacket from '../packet/LoginPacket';
 import ResourcePacksInfoPacket from '../packet/ResourcePacksInfoPacket';
-import type Server from '../../Server';
+import PlayStatusType from '../type/PlayStatusType';
+import type PreLoginPacketHandler from './PreLoginPacketHandler';
 
 export default class LoginHandler implements PreLoginPacketHandler<LoginPacket> {
     public static NetID = Identifiers.LoginPacket;
@@ -58,7 +58,7 @@ export default class LoginHandler implements PreLoginPacketHandler<LoginPacket> 
             return;
         }
 
-        await player.onEnable();
+        await player.enable();
 
         // TODO: encryption handshake
 

--- a/packages/prismarine/src/permission/PermissionManager.ts
+++ b/packages/prismarine/src/permission/PermissionManager.ts
@@ -36,7 +36,7 @@ export class PermissionManager implements Service {
      * @returns {Promise<void>} A promise that resolves when the manager is enabled.
      * @async
      */
-    public async onEnable(): Promise<void> {
+    public async enable(): Promise<void> {
         await this.parseOps();
         await this.parsePermissions();
     }
@@ -46,7 +46,7 @@ export class PermissionManager implements Service {
      * @returns {Promise<void>} A promise that resolves when the manager is disabled.
      * @async
      */
-    public async onDisable(): Promise<void> {
+    public async disable(): Promise<void> {
         this.ops.clear();
         this.permissions.clear();
         this.defaultPermissions = [];

--- a/packages/prismarine/src/utils/Logger.ts
+++ b/packages/prismarine/src/utils/Logger.ts
@@ -1,13 +1,13 @@
+import colorParser from '@jsprismarine/color-parser';
 import type { Logger } from 'winston';
 import { createLogger, format, transports } from 'winston';
 import Transport from 'winston-transport';
-import colorParser from '@jsprismarine/color-parser';
 
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { cwd } from './cwd';
 import type Console from '../Console';
+import { cwd } from './cwd';
 
 const { combine, timestamp, printf } = format;
 
@@ -112,12 +112,12 @@ export default class LoggerBuilder {
         (this.logger.transports[0] as PrismarineTransport).console = console;
     }
 
-    public async onEnable(): Promise<void> {
+    public async enable(): Promise<void> {
         this.createLogger();
         this.logger.level = global.logLevel ?? 'info';
     }
 
-    public async onDisable(): Promise<void> {
+    public async disable(): Promise<void> {
         // TODO: Fix this
         //this.logger.close();
         //this.logger.destroy();

--- a/packages/prismarine/src/utils/Service.ts
+++ b/packages/prismarine/src/utils/Service.ts
@@ -4,12 +4,12 @@ export abstract class Service {
      * @returns {Promise<void>} A promise that resolves when the service is enabled.
      * @async
      */
-    public abstract onEnable(): Promise<void>;
+    public abstract enable(): Promise<void>;
 
     /**
      * Disable the service.
      * @returns {Promise<void>} A promise that resolves when the service is disabled.
      * @async
      */
-    public abstract onDisable(): Promise<void>;
+    public abstract disable(): Promise<void>;
 }

--- a/packages/prismarine/src/world/World.ts
+++ b/packages/prismarine/src/world/World.ts
@@ -1,24 +1,24 @@
 import GameruleManager, { GameRules } from './GameruleManager';
 
-import type BaseProvider from './providers/BaseProvider';
-import type { Block } from '../block/Block';
-import { BlockMappings } from '../block/BlockMappings';
-import Chunk from './chunk/Chunk';
-import { Gamemode } from './';
-import type { Generator } from './Generator';
-import { Item } from '../item/Item';
-import LevelSoundEventPacket from '../network/packet/LevelSoundEventPacket';
+import minifyJson from 'strip-json-comments';
 import type Player from '../Player';
 import type Server from '../Server';
-import Timer from '../utils/Timer';
-import UUID from '../utils/UUID';
-import UpdateBlockPacket from '../network/packet/UpdateBlockPacket';
-import Vector3 from '../math/Vector3';
-import WorldEventPacket from '../network/packet/WorldEventPacket';
-import { cwd } from '../utils/cwd';
-import minifyJson from 'strip-json-comments';
+import type { Block } from '../block/Block';
+import { BlockMappings } from '../block/BlockMappings';
 import * as Entities from '../entity/Entities';
 import type { Entity } from '../entity/Entity';
+import { Item } from '../item/Item';
+import Vector3 from '../math/Vector3';
+import LevelSoundEventPacket from '../network/packet/LevelSoundEventPacket';
+import UpdateBlockPacket from '../network/packet/UpdateBlockPacket';
+import WorldEventPacket from '../network/packet/WorldEventPacket';
+import Timer from '../utils/Timer';
+import UUID from '../utils/UUID';
+import { cwd } from '../utils/cwd';
+import { Gamemode } from './';
+import type { Generator } from './Generator';
+import Chunk from './chunk/Chunk';
+import type BaseProvider from './providers/BaseProvider';
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -98,7 +98,7 @@ export class World {
         }
     }
 
-    public async onEnable(): Promise<void> {
+    public async enable(): Promise<void> {
         this.server.on('tick', async (evt) => this.update(evt.getTick()));
 
         const level = await this.getLevelData();
@@ -127,7 +127,7 @@ export class World {
         }
 
         this.provider.setWorld(this);
-        await this.provider.onEnable();
+        await this.provider.enable();
 
         this.server
             .getLogger()
@@ -146,9 +146,9 @@ export class World {
         this.server.getLogger().verbose(`(took §e${timer.stop()} ms§r)`);
     }
 
-    public async onDisable() {
+    public async disable() {
         await this.save();
-        await this.provider.onDisable();
+        await this.provider.disable();
     }
 
     public getGenerator(): Generator {

--- a/packages/prismarine/src/world/WorldManager.ts
+++ b/packages/prismarine/src/world/WorldManager.ts
@@ -1,9 +1,8 @@
-import Filesystem from './providers/filesystem/Filesystem';
-import { GeneratorManager } from './';
-import type Provider from './providers/Provider';
 import type Server from '../Server';
-import { World } from './';
 import { cwd } from '../utils/cwd';
+import { GeneratorManager, World } from './';
+import type Provider from './providers/Provider';
+import Filesystem from './providers/filesystem/Filesystem';
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -40,7 +39,7 @@ export default class WorldManager {
     /**
      * Enable the manager and load all worlds.
      */
-    public async onEnable(): Promise<void> {
+    public async enable(): Promise<void> {
         this.addProvider('Filesystem', Filesystem);
 
         const defaultWorld = this.server.getConfig().getLevelName();
@@ -58,7 +57,7 @@ export default class WorldManager {
     /**
      * Signifies that the manager is being disabled and all worlds should be unloaded.
      */
-    public async onDisable(): Promise<void> {
+    public async disable(): Promise<void> {
         await Promise.all(this.getWorlds().map(async (world) => this.unloadWorld(world.getName())));
         this.providers.clear();
     }
@@ -144,7 +143,7 @@ export default class WorldManager {
 
         this.server.getLogger().verbose(`World §b${folderName}§r successfully loaded!`);
 
-        await world.onEnable();
+        await world.enable();
         return world;
     }
 
@@ -163,7 +162,7 @@ export default class WorldManager {
             return;
         }
 
-        await world.onDisable();
+        await world.disable();
         this.worlds.delete(world.getUUID());
         this.server.getLogger().verbose(`Successfully unloaded world §b${folderName}§f!`);
     }

--- a/packages/prismarine/src/world/providers/BaseProvider.ts
+++ b/packages/prismarine/src/world/providers/BaseProvider.ts
@@ -1,7 +1,7 @@
-import type Chunk from '../chunk/Chunk';
 import type { Generator, World } from '../';
-import type Provider from './Provider';
 import type { Server } from '../../';
+import type Chunk from '../chunk/Chunk';
+import type Provider from './Provider';
 
 import fs from 'node:fs';
 
@@ -25,8 +25,8 @@ export default abstract class BaseProvider implements Provider {
         return this.world;
     }
 
-    public async onEnable() {}
-    public async onDisable() {}
+    public async enable() {}
+    public async disable() {}
 
     public getServer(): Server {
         return this.server;


### PR DESCRIPTION
`onEnable` and `onDisable` were really silly names in hindsight. Let's finally rectify this.