### PR TITLE
Prismarine+Parity: Treat console input as commands instead of as chat.

### DIFF
--- a/.changeset/loml.md
+++ b/.changeset/loml.md
@@ -1,0 +1,12 @@
+---
+'@jsprismarine/prismarine': patch
+---
+
+As a parity change with Java and BDS the console will no longer require
+you to type a `/` (slash) before running a command. As a consequence of
+this change the chat functionality of the console has been removed, to
+send chat messages now you will need to use one of the many commands
+like `/say`, `/me`, `/tellraw`, and more.
+
+All on `enable` and `disable` hooks have now been documented with JSDoc
+and also given proper return types.

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -49,10 +49,18 @@ export class Logger {
         });
     }
 
+    /**
+     * On enable hook.
+     * @async
+     */
     public async enable(): Promise<void> {
         this.createLogger();
     }
 
+    /**
+     * On disable hook.
+     * @async
+     */
     public async disable(): Promise<void> {
         this.logger.close();
         this.logger.destroy();

--- a/packages/prismarine/src/Player.ts
+++ b/packages/prismarine/src/Player.ts
@@ -85,7 +85,11 @@ export default class Player extends Human {
         this.server.on('chat', this.chatHandler.bind(this));
     }
 
-    public async enable() {
+    /**
+     * On enable hook.
+     * @async
+     */
+    public async enable(): Promise<void> {
         const playerData = await this.getWorld().getPlayerData(this);
 
         this.permissions = await this.server.getPermissionManager().getPermissions(this);
@@ -116,7 +120,11 @@ export default class Player extends Human {
         this.connected = true;
     }
 
-    public async disable() {
+    /**
+     * On disable hook.
+     * @async
+     */
+    public async disable(): Promise<void> {
         if (this.connected && this.xuid) await this.getWorld().savePlayerData(this);
         await this.getWorld().removeEntity(this);
 

--- a/packages/prismarine/src/ban/BanManager.ts
+++ b/packages/prismarine/src/ban/BanManager.ts
@@ -23,11 +23,19 @@ export default class BanManager {
         this.server = server;
     }
 
-    public async enable() {
+    /**
+     * On enable hook.
+     * @async
+     */
+    public async enable(): Promise<void> {
         await this.parseBanned();
     }
 
-    public async disable() {
+    /**
+     * On disable hook.
+     * @async
+     */
+    public async disable(): Promise<void> {
         this.banned.clear();
     }
 

--- a/packages/prismarine/src/block/BlockManager.ts
+++ b/packages/prismarine/src/block/BlockManager.ts
@@ -16,16 +16,18 @@ export default class BlockManager {
     }
 
     /**
-     * OnEnable hook.
+     * On enable hook.
+     * @async
      */
-    public async enable() {
+    public async enable(): Promise<void> {
         await this.importBlocks();
     }
 
     /**
-     * OnDisable hook.
+     * On disable hook.
+     * @async
      */
-    public async disable() {
+    public async disable(): Promise<void> {
         this.blocks.clear();
     }
 

--- a/packages/prismarine/src/command/CommandManager.ts
+++ b/packages/prismarine/src/command/CommandManager.ts
@@ -23,7 +23,11 @@ export class CommandManager implements Service {
         this.dispatcher = new CommandDispatcher();
     }
 
-    public async enable() {
+    /**
+     * On enable hook.
+     * @async
+     */
+    public async enable(): Promise<void> {
         const timer = new Timer();
 
         const commands = Object.keys(Commands).map((key) => (Commands as any)[key] as typeof Command);
@@ -51,7 +55,11 @@ export class CommandManager implements Service {
             .verbose(`Registered §b${this.commands.size}§r commands(s) (took §e${timer.stop()} ms§r)!`);
     }
 
-    public async disable() {
+    /**
+     * On disable hook.
+     * @async
+     */
+    public async disable(): Promise<void> {
         this.commands.clear();
         // TODO: clear commands in dispatcher
     }

--- a/packages/prismarine/src/config/Config.ts
+++ b/packages/prismarine/src/config/Config.ts
@@ -29,6 +29,10 @@ export class Config {
         this.logLevel = this.configBuilder.get('log-level', isDev ? 'verbose' : 'info');
     }
 
+    /**
+     * On enable hook.
+     * @async
+     */
     public async enable(): Promise<void> {
         this.configBuilder = new ConfigBuilder(path.resolve(cwd(), 'config.yaml'));
         this.logLevel = this.configBuilder.get('log-level', isDev ? 'verbose' : 'info');
@@ -50,6 +54,10 @@ export class Config {
         this.packetCompressionLevel = this.configBuilder.get('packet-compression-level', 7) as number;
     }
 
+    /**
+     * On disable hook.
+     * @async
+     */
     public async disable(): Promise<void> {}
 
     public getLogLevel(): LogLevel {

--- a/packages/prismarine/src/item/ItemManager.ts
+++ b/packages/prismarine/src/item/ItemManager.ts
@@ -21,15 +21,15 @@ export default class ItemManager {
     }
 
     /**
-     * OnEnable hook.
+     * On enable hook.
      * @async
      */
-    public async enable() {
+    public async enable(): Promise<void> {
         await this.importItems();
     }
 
     /**
-     * OnDisable hook.
+     * On disable hook.
      * @async
      */
     public async disable() {

--- a/packages/prismarine/src/network/PacketRegistry.ts
+++ b/packages/prismarine/src/network/PacketRegistry.ts
@@ -17,12 +17,20 @@ export default class PacketRegistry {
         this.server = server;
     }
 
-    public async enable() {
+    /**
+     * On enable hook.
+     * @async
+     */
+    public async enable(): Promise<void> {
         await this.registerPackets();
         await this.registerHandlers();
     }
 
-    public async disable() {
+    /**
+     * On disable hook.
+     * @async
+     */
+    public async disable(): Promise<void> {
         this.handlers.clear();
         this.packets.clear();
     }

--- a/packages/prismarine/src/world/World.ts
+++ b/packages/prismarine/src/world/World.ts
@@ -95,6 +95,10 @@ export class World implements Service {
         }
     }
 
+    /**
+     * On enable hook.
+     * @async
+     */
     public async enable(): Promise<void> {
         this.server.on('tick', async (evt) => this.update(evt.getTick()));
 
@@ -142,7 +146,11 @@ export class World implements Service {
         this.server.getLogger().verbose(`(took §e${timer.stop()} ms§r)`);
     }
 
-    public async disable() {
+    /**
+     * On disable hook.
+     * @async
+     */
+    public async disable(): Promise<void> {
         await this.save();
         await this.provider.disable();
     }

--- a/packages/prismarine/src/world/WorldManager.ts
+++ b/packages/prismarine/src/world/WorldManager.ts
@@ -42,7 +42,8 @@ export default class WorldManager implements Service {
     }
 
     /**
-     * Enable the manager and load all worlds.
+     * On enable hook, enables the manager and load all worlds.
+     * @async
      */
     public async enable(): Promise<void> {
         this.addProvider('Anvil', Anvil);
@@ -61,8 +62,13 @@ export default class WorldManager implements Service {
     }
 
     /**
+     * On disable hook.
+     *
      * Signifies that the manager is being disabled and all worlds should be unloaded.
+     *
+     * @async
      */
+    public async disable(): Promise<void>;
     public async disable(): Promise<void> {
         await Promise.all(this.getWorlds().map(async (world) => this.unloadWorld(world.getName())));
         this.providers.clear();

--- a/packages/prismarine/src/world/providers/BaseProvider.ts
+++ b/packages/prismarine/src/world/providers/BaseProvider.ts
@@ -25,7 +25,15 @@ export default abstract class BaseProvider implements Provider {
         return this.world;
     }
 
+    /**
+     * On enable hook.
+     * @async
+     */
     public async enable(): Promise<void> {}
+    /**
+     * On disable hook.
+     * @async
+     */
     public async disable(): Promise<void> {}
 
     public getServer(): Server {

--- a/packages/prismarine/src/world/providers/anvil/Anvil.ts
+++ b/packages/prismarine/src/world/providers/anvil/Anvil.ts
@@ -25,10 +25,18 @@ export default class Anvil extends BaseProvider {
         );
     }
 
-    public async enable() {
+    /**
+     * On enable hook.
+     * @async
+     */
+    public async enable(): Promise<void> {
         await this.prepareFolderStructure();
     }
-    public async disable() {}
+    /**
+     * On disable hook.
+     * @async
+     */
+    public async disable(): Promise<void> {}
 
     public async readChunk(cx: number, cz: number, seed: number, generator: Generator, config?: any): Promise<Chunk> {
         return generator.generateChunk(cx, cz, seed, config);


### PR DESCRIPTION
As a parity change with Java and BDS the console will no longer require you to type a `/` (slash) before running a command. As a consequence of this change the chat functionality of the console has been removed, to send chat messages now you will need to use one of the many commands like `/say`, `/me`, `/tellraw`, and more.

All on `enable` and `disable` hooks have now been documented with JSDoc and also given proper return types.