### PR TITLE
Dev/mcsleepingserverstarter

### DIFF
--- a/packages/prismarine/src/Server.ts
+++ b/packages/prismarine/src/Server.ts
@@ -354,7 +354,7 @@ export default class Server extends EventEmitter {
      * @param {boolean} [options.crash] - If the server should crash.
      * @returns {Promise<void>} A promise that resolves when the server is killed.
      */
-    public async shutdown(options?: { crash?: boolean }): Promise<void> {
+    public async shutdown(options?: { crash?: boolean; stayAlive?: boolean }): Promise<void> {
         if (this.stopping) return;
         this.stopping = true;
 
@@ -379,10 +379,14 @@ export default class Server extends EventEmitter {
 
             this.getLogger().info('Server stopped, Goodbye!\n');
 
-            process.exit(options?.crash ? 1 : 0);
+            if (!options?.stayAlive) {
+                process.exit(options?.crash ? 1 : 0);
+            }
         } catch (error: unknown) {
-            console.error(error);
-            process.exit(1);
+            this.logger.error(error);
+            if (!options?.stayAlive) {
+                process.exit(1);
+            }
         }
     }
 


### PR DESCRIPTION
Hi,
It would be good if the prismarine server does not kill its parent process when exiting.
Thanks.