### PR TITLE
brigadier: Fix reading string with mismatched single/double quotes

### DIFF
--- a/packages/brigadier/src/StringReader.test.ts
+++ b/packages/brigadier/src/StringReader.test.ts
@@ -136,6 +136,26 @@ describe('StringReader Test', () => {
         assert.equal(reader.getRemaining(), '');
     });
 
+    it('readSingleQuotedString_mismatchedQuotes', () => {
+        try {
+            new StringReader(`'hello world"`).readQuotedString();
+            assert.fail();
+        } catch (ex: any) {
+            assert.equal(ex.getType(), CommandSyntaxException.BUILT_IN_EXCEPTIONS.readerExpectedEndOfQuote());
+            assert.equal(ex.getCursor(), 13);
+        }
+    });
+
+    it('readDoubleQuotedString_mismatchedQuotes', () => {
+        try {
+            new StringReader(`"hello world'`).readQuotedString();
+            assert.fail();
+        } catch (ex: any) {
+            assert.equal(ex.getType(), CommandSyntaxException.BUILT_IN_EXCEPTIONS.readerExpectedEndOfQuote());
+            assert.equal(ex.getCursor(), 13);
+        }
+    });
+
     it('readQuotedString_empty', () => {
         const reader = new StringReader('');
         assert.equal(reader.readQuotedString(), '');

--- a/packages/brigadier/src/StringReader.ts
+++ b/packages/brigadier/src/StringReader.ts
@@ -136,7 +136,7 @@ export default class StringReader implements ImmutableStringReader {
             throw CommandSyntaxException.BUILT_IN_EXCEPTIONS.readerExpectedStartOfQuote().createWithContext(this);
         }
 
-        this.skip();
+        const startQuote = this.read();
         let result = '';
         let escaped = false;
         while (this.canRead()) {
@@ -151,7 +151,7 @@ export default class StringReader implements ImmutableStringReader {
                 }
             } else if (c == SYNTAX_ESCAPE) {
                 escaped = true;
-            } else if (c == SYNTAX_SINGLE_QUOTE || c == SYNTAX_DOUBLE_QUOTE) {
+            } else if (c == startQuote) {
                 return result;
             } else {
                 result += c;


### PR DESCRIPTION
PR #2014 introduced reading single quoted strings, but allows a quoted string to end with a mismatched quote.

Related to #1956.