### PR TITLE
Fix: Generate bedrock-data resources before running dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "scripts": {
         "prepare": "husky || true",
         "start": "node ./packages/server/dist/Server.es.js --warning --circular",
+        "predev": "pnpm --filter ./packages/bedrock-data run generate",
         "dev": "pnpm --filter ./packages/server run dev",
+        "predev:bun": "pnpm --filter ./packages/bedrock-data run generate",
         "dev:bun": "pnpm --filter ./packages/server run dev:bun",
         "clean": "turbo run clean",
         "build": "turbo run build --env-mode=loose",

--- a/packages/bedrock-data/package.json
+++ b/packages/bedrock-data/package.json
@@ -32,7 +32,8 @@
     },
     "scripts": {
         "clean": "rimraf dist jsp *.tsbuildinfo vite.config.ts.timestamp-* .tsup .turbo",
-        "build": "node utils/build.js && vite build",
+        "generate": "node utils/build.js",
+        "build": "pnpm run generate && vite build",
         "build:watch": "pnpm run build",
         "typecheck": "tsc -noEmit"
     },

--- a/packages/bedrock-data/utils/build.js
+++ b/packages/bedrock-data/utils/build.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 
 const files = [
     'resources/biome_definitions.nbt',
@@ -8,18 +9,36 @@ const files = [
     'resources/r12_to_current_block_map.bin'
 ];
 
+const force = process.argv.includes('--force');
+
+const isUpToDate = (source, target) => {
+    const generated = fs.statSync(target, { throwIfNoEntry: false });
+    return generated !== undefined && generated.mtimeMs >= fs.statSync(source).mtimeMs;
+};
+
 for (const file of files) {
     const filename = path.basename(file);
+
+    const source = path.resolve('src/', file);
+    const target = path.resolve('src/generated', `${filename.split('.').slice(0, -1).join('.')}.json`);
+
+    if (!fs.existsSync(source)) {
+        console.error(
+            `Missing ${file}. The bedrock-data resources are a git submodule, run \`git submodule update --init --recursive\` from the repository root.`
+        );
+        process.exit(1);
+    }
+
+    if (!force && isUpToDate(source, target)) {
+        continue;
+    }
+
     console.log(`Converting ${filename}...`);
 
-    const dir = path.resolve('src/', file);
-    const raw = fs.readFileSync(dir);
+    const raw = fs.readFileSync(source);
     console.log(`file size: ${raw.length} bytes`);
 
     const data = raw.toString('base64');
 
-    fs.writeFileSync(
-        path.resolve('src/generated', `${filename.split('.').slice(0, -1).join('.')}.json`),
-        JSON.stringify({ data }, null, 0)
-    );
+    fs.writeFileSync(target, JSON.stringify({ data }, null, 0));
 }


### PR DESCRIPTION
## Problem

On a fresh clone, `pnpm run dev` fails before the server starts:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'.../packages/bedrock-data/src/generated/biome_definitions.json'
imported from .../packages/bedrock-data/src/index.ts
```

`src/generated/*.json` is produced by `packages/bedrock-data/utils/build.js`, which only runs as part of `build`. `dev` imports those files but never generates them, so dev only works if a build happened first. The error is hard to act on because the path it names is gitignored, so it looks like a missing file rather than a missing build step.

## Changes

- Extract the conversion into a `generate` script in `@jsprismarine/bedrock-data`; `build` now calls it, so that path is unchanged.
- Run `generate` from a root `predev` / `predev:bun` hook, so `pnpm run dev` works standalone.
- The generator skips outputs newer than their source, so the added step is a no-op once warm. `--force` rebuilds everything.
- A missing source file now reports that the resources live in a submodule instead of throwing a bare `ENOENT` — forgetting `--recurse-submodules` lands on exactly this code path.

## Testing

| Case | Result |
|---|---|
| Empty `src/generated/`, `pnpm run dev` | generates all 4 files, server starts |
| Single file missing | converts only that one |
| Re-run when warm | no-op |
| `--force` | regenerates everything |
| Submodule not initialized | actionable message, exit 1 |
| `pnpm run build` | 13/13 tasks pass |

## Note

`predev` relies on pnpm's `enable-pre-post-scripts`, which is not pinned in `.npmrc`. It works on the pnpm version this repo pins (11.20.0), but if you would rather not depend on that setting, I am happy to chain it explicitly instead:

```json
"dev": "pnpm --filter ./packages/bedrock-data run generate && pnpm --filter ./packages/server run dev"
```
